### PR TITLE
Fix moving items: Copy item instead of creating from strach

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,10 @@ tasks.test {
     useJUnitPlatform()
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "17"
+java {
+  toolchain {
+      languageVersion.set(JavaLanguageVersion.of(17))
+  }
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
@@ -47,12 +49,4 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         endWithNewline()
         trimTrailingWhitespace()
     }
-}
-val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = "17"
-}
-val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = "17"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.5.0"
+    kotlin("jvm") version "1.7.0"
     id("com.diffplug.spotless") version "5.14.1"
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 group = "tf.sou.mc"
-version = "1.0-SNAPSHOT"
+version = "1.3-SNAPSHOT"
 
 repositories {
     mavenCentral()
@@ -15,11 +15,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.17-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.19.2-R0.1-SNAPSHOT")
     testImplementation(kotlin("test-junit5"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.0")
-    testImplementation("org.assertj:assertj-core:3.11.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.0")
+    testImplementation("org.assertj:assertj-core:3.23.1")
+    implementation(kotlin("stdlib-jdk8"))
 }
 
 configurations {
@@ -31,7 +32,7 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "16"
+    kotlinOptions.jvmTarget = "17"
 }
 
 configure<com.diffplug.gradle.spotless.SpotlessExtension> {
@@ -46,4 +47,12 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         endWithNewline()
         trimTrailingWhitespace()
     }
+}
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+    jvmTarget = "17"
+}
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+    jvmTarget = "17"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "tf.sou.mc"
-version = "1.3-SNAPSHOT"
+version = "1.1-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/tf/sou/mc/pal/listeners/ChestListener.kt
+++ b/src/main/kotlin/tf/sou/mc/pal/listeners/ChestListener.kt
@@ -110,12 +110,8 @@ class ChestListener(private val pal: ChestPal) : Listener {
         }
         // Clean up.
         badItems.forEach {
-            if (it != null) {
-                inventory.remove(it)
-            }
-            if (it != null) {
-                event.player.inventory.addItem(it)
-            }
+            inventory.remove(it)
+            event.player.inventory.addItem(it)         
         }
         event.player.sendMessage("This receiver chest only takes ${allowedItem.toPrettyString()}!")
     }

--- a/src/main/kotlin/tf/sou/mc/pal/utils/extensions.kt
+++ b/src/main/kotlin/tf/sou/mc/pal/utils/extensions.kt
@@ -105,8 +105,12 @@ fun Inventory.countAvailableSpace(item: Material): Int {
 /**
  * Attempts to find items in an inventory that differ from the provided [Material].
  */
-fun Inventory.findBadItems(allowed: Material): List<ItemStack?> {
-    return contents.filter { it != null && it.type != allowed }
+fun Inventory.findBadItems(allowed: Material): List<ItemStack> {
+    val filteredInventory = mutableListOf<ItemStack>()
+    for (item in contents) {
+        if (item != null && item.type != allowed) filteredInventory.add(item)
+    }
+    return filteredInventory
 }
 
 /**

--- a/src/main/kotlin/tf/sou/mc/pal/utils/extensions.kt
+++ b/src/main/kotlin/tf/sou/mc/pal/utils/extensions.kt
@@ -87,10 +87,10 @@ fun Location.resolveContainer(): Container? {
  * Partitions this integer into a list of item stacks based
  * on the maximum stack size of the provided [Material].
  */
-fun Int.asItemStacks(material: Material): List<ItemStack> {
+fun Int.asItemStacks(material: ItemStack): List<ItemStack> {
     val size = material.maxStackSize
-    val chunks = (1..this / size).map { ItemStack(material, size) }
-    return (this % size).takeIf { it != 0 }?.let { chunks + ItemStack(material, it) } ?: chunks
+    val chunks = (1..this / size).map { material.amount = size ; material}
+    return (this % size).takeIf { it != 0 }?.let {material.amount=it ; chunks + material } ?: chunks
 }
 
 /**
@@ -105,7 +105,7 @@ fun Inventory.countAvailableSpace(item: Material): Int {
 /**
  * Attempts to find items in an inventory that differ from the provided [Material].
  */
-fun Inventory.findBadItems(allowed: Material): List<ItemStack> {
+fun Inventory.findBadItems(allowed: Material): List<ItemStack?> {
     return contents.filter { it != null && it.type != allowed }
 }
 


### PR DESCRIPTION
I installed the plugin on my server and tested it with a couple of items and I realized the plugin couldn't move enchanted items or books. Also while moving items, I also saw items with lower durability replaced with full health items. 
I debug the code and find out that the `asItemStacks` function creates the item by looking at the item name.

This pr is to fix this, whit the new code changes now the plugin only moves the **Real item** to the desired chest.